### PR TITLE
extend login period to 30days

### DIFF
--- a/pages/[recordID].js
+++ b/pages/[recordID].js
@@ -95,7 +95,7 @@ export async function getServerSideProps(ctx) {
     )
 
     return {
-      props: { query, application, leaders, trackedApp, session: true },
+      props: { query, application, leaders, trackedApp, session },
       notFound: false
     }
   } catch (e) {

--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -6,14 +6,7 @@ const options = {
   // Configure one or more authentication providers
   providers: [
     Providers.Email({
-      server: {
-        host: process.env.EMAIL_SERVER_HOST,
-        port: process.env.EMAIL_SERVER_PORT,
-        auth: {
-          user: process.env.EMAIL_SERVER_USERNAME,
-          pass: process.env.EMAIL_SERVER_PASSWORD
-        }
-      },
+      server: process.env.EMAIL_SERVER,
       from: process.env.EMAIL_FROM,
       maxAge: 30 * 24 * 60 * 60 // 30 days
     })


### PR DESCRIPTION
This PR will extend a login session to 30 days, it uses Sendgrid as Amazon SES is not working on Vercel.